### PR TITLE
Fix MCPServerStdio timeout option

### DIFF
--- a/manager.py
+++ b/manager.py
@@ -175,9 +175,12 @@ class JobSearchManager:
         async with MCPServerStdio(
             params={
                 "command": "mcp-searxng",
-                "env": {"SEARXNG_URL": "http://localhost:8080/", "SEARXNG_MCP_TIMEOUT": "30"},
-                "client_session_timeout_seconds": 25,
-            }
+                "env": {
+                    "SEARXNG_URL": "http://localhost:8080/",
+                    "SEARXNG_MCP_TIMEOUT": "30",
+                },
+            },
+            client_session_timeout_seconds=25,
         ) as searxng_server:
             # Determine URLs to process
             if self.urls:


### PR DESCRIPTION
## Summary
- fix how timeout is passed to `MCPServerStdio`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68404672f72c8332bd21d97a4c138a24