### PR TITLE
Add desired-count param; remove top-n

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ This repository demonstrates a multi-agent system that automates the job search 
 
 Here are three ways to run the pipeline with the example files `example/resume.txt.sample` and `example/preferences.txt.sample`:
 
-1. Run the full search + screen pipeline and save results. Specifying `--top-n` means only up to `--top-n` URLs are sent through the job screening.
+1. Run the full search + screen pipeline and save results. Use `--desired-count` to keep searching additional pages until at least that many jobs are successfully screened.
 
 ```bash
-python main.py --job-title "software engineer" --resume example/resume.txt.sample --preferences example/preferences.txt.sample --output example/report.txt.sample --top-n 10
+python main.py --job-title "software engineer" --resume example/resume.txt.sample --preferences example/preferences.txt.sample --output example/report.txt.sample --desired-count 10
 ```
 - You can examine the output in `example/report.txt.sample`
 

--- a/job_agents/searcher.py
+++ b/job_agents/searcher.py
@@ -17,11 +17,12 @@ class SearchResults(BaseModel):
     """The URLs of the job postings"""
 
 
-def build_job_searcher_agent(query: str):
+def build_job_searcher_agent(query: str, pageno: int = 1):
+    """Build the job searcher agent for the given query and page number."""
     INSTRUCTIONS = (
         f"You job is to search for {query} jobs. "
         "When searching, use the web_search tool and ALWAYS use the exact query "
-        f"{query} gh_jid' with pageno=1 and language='en'. "
+        f"'{query} gh_jid' with pageno={pageno} and language='en'. "
         "Extract a list of URLs from the search results and store in the SearchResults.job_urls field. "
         "Only include URLs with a job id parameter like 'gh_jid' in the URL. "
     )
@@ -29,5 +30,5 @@ def build_job_searcher_agent(query: str):
         name="Job Search Agent",
         instructions=INSTRUCTIONS,
         model="gpt-4.1-mini",
-        output_type=SearchResults
-    ) 
+        output_type=SearchResults,
+    )

--- a/main.py
+++ b/main.py
@@ -25,8 +25,8 @@ def parse_args() -> argparse.Namespace:
         help="File path to preferences (for the screening agent)"
     )
     parser.add_argument(
-        "-n", "--top-n", dest="top_n", type=int,
-        help="Only screen the first N URLs"
+        "-d", "--desired-count", dest="desired_count", type=int,
+        help="Desired number of successful job screenings"
     )
     parser.add_argument(
         "-s", "--search-only", dest="search_only", action="store_true",
@@ -46,7 +46,7 @@ async def main():
         resume_path=args.resume_path,
         preferences_path=args.preferences_path,
         urls=args.urls,
-        top_n=args.top_n,
+        desired_count=args.desired_count,
         search_only=args.search_only
     )
     results = await manager.run()


### PR DESCRIPTION
## Summary
- remove deprecated `--top-n` option
- update README usage example to rely on `--desired-count`
- clean up manager logic to use desired count only

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install python-dotenv` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68404f7d860883328c3420697d4d012a