### PR TITLE
Add logging and write report to output

### DIFF
--- a/job_agents/context.py
+++ b/job_agents/context.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel
 from agents import RunContextWrapper, function_tool, ToolsToFinalOutputResult, FunctionToolResult
 from typing import Literal
 import textwrap
+import logging
 
 
 class JobScreenContext(BaseModel):
@@ -179,4 +180,4 @@ async def record_error_on_handoff(ctx: RunContextWrapper[JobScreenContext], erro
     """Record the error message in the context"""
     ctx.context.error_message = error_message.message
     ctx.context.failed = True
-    print(f"\n⚠️ Unable to screen job posting:\n\n{repr(error_message)}")
+    logging.warning(f"Unable to screen job posting: {repr(error_message)}")


### PR DESCRIPTION
## Summary
- add CLI arg for specifying a log file
- default log path uses job title and timestamp under `logs/`
- configure logging in `main.py`
- log CLI arguments and workflow messages instead of printing
- return report string from `compile_report` and append to output file

## Testing
- `pytest -q`
- `python -m py_compile main.py manager.py job_agents/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6840b781c2f483329797076baaf2b1f3